### PR TITLE
Refine recurring transaction helpers and tighten financial forms

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -89,23 +89,6 @@ class RecorrenteReceitaForm(forms.ModelForm):
         model = Receita
         fields = ['descricao', 'valor', 'categoria', 'conta']
 
-class CategoriaForm(forms.ModelForm):
-    class Meta:
-        model = Categoria
-        fields = ['nome', 'orcamento_mensal', 'categoria_mae']
-
-    def __init__(self, *args, **kwargs):
-        # Pega a família que a view vai passar
-        familia = kwargs.pop('familia', None)
-        super().__init__(*args, **kwargs)
-
-        if familia:
-            # Mostra apenas as categorias principais da família como opções para "categoria_mae"
-            self.fields['categoria_mae'].queryset = Categoria.objects.filter(
-                familia=familia, 
-                categoria_mae__isnull=True
-            )
-
 class CategoriaReceitaForm(forms.ModelForm):
     class Meta:
         model = CategoriaReceita
@@ -149,7 +132,11 @@ class AporteInvestimentoForm(forms.ModelForm):
         widgets = {'data': forms.DateInput(attrs={'type': 'date'})}
 
 class PagamentoFaturaForm(forms.Form):
-    conta_pagamento = forms.ModelChoiceField(queryset=Conta.objects.all(), label="Pagar com a conta", widget=forms.Select(attrs={'class': 'form-select'}))
+    conta_pagamento = forms.ModelChoiceField(
+        queryset=Conta.objects.none(),
+        label="Pagar com a conta",
+        widget=forms.Select(attrs={'class': 'form-select'})
+    )
     data_pagamento = forms.DateField(widget=forms.DateInput(attrs={'type': 'date'}), initial=date.today, label="Data do Pagamento")
     def __init__(self, *args, **kwargs):
         familia = kwargs.pop('familia', None)
@@ -161,7 +148,7 @@ class PagamentoFaturaForm(forms.Form):
 # --- APORTEFORM ATUALIZADO ---
 class AporteForm(forms.Form):
     valor = forms.DecimalField(max_digits=15, decimal_places=2, label="Valor do Aporte")
-    conta_origem = forms.ModelChoiceField(queryset=Conta.objects.all(), label="Conta de Origem")
+    conta_origem = forms.ModelChoiceField(queryset=Conta.objects.none(), label="Conta de Origem")
 
     def __init__(self, *args, **kwargs):
         user = kwargs.pop('user', None)
@@ -170,7 +157,7 @@ class AporteForm(forms.Form):
             self.fields['conta_origem'].queryset = Conta.objects.filter(familia=user.perfil.familia)
         else:
             self.fields['conta_origem'].queryset = Conta.objects.none()
-            
+
 class CategoriaForm(forms.ModelForm):
     class Meta:
         model = Categoria
@@ -182,6 +169,6 @@ class CategoriaForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         if familia:
             self.fields['categoria_mae'].queryset = Categoria.objects.filter(
-                familia=familia, 
+                familia=familia,
                 categoria_mae__isnull=True
             )

--- a/core/tests.py
+++ b/core/tests.py
@@ -74,7 +74,8 @@ class DashboardViewTest(TestCase):
         """
         response = self.client.get(reverse('dashboard'))
         self.assertEqual(response.status_code, 302)
-        self.assertRedirects(response, f"{reverse('login')}?next=/")
+        expected_url = f"{reverse('login')}?next={reverse('dashboard')}"
+        self.assertRedirects(response, expected_url, fetch_redirect_response=False)
 
     def test_dashboard_acessivel_para_usuario_logado(self):
         """
@@ -84,4 +85,4 @@ class DashboardViewTest(TestCase):
         response = self.client.get(reverse('dashboard'))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'core/dashboard.html')
-        self.assertContains(response, "Dashboard Financeiro")
+        self.assertContains(response, "Saldo em Contas")

--- a/core/views/transacoes.py
+++ b/core/views/transacoes.py
@@ -1,4 +1,6 @@
 import uuid
+from typing import Callable
+
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
@@ -8,6 +10,24 @@ from django.core.paginator import Paginator
 
 from core.models import Despesa, Receita
 from core.forms import DespesaForm, ReceitaForm, RecorrenteDespesaForm, RecorrenteReceitaForm
+
+
+FREQUENCIA_DELTAS: dict[str, Callable[[int], relativedelta]] = {
+    'semanal': lambda i: relativedelta(weeks=i),
+    'quinzenal': lambda i: relativedelta(weeks=i * 2),
+    'mensal': lambda i: relativedelta(months=i),
+    'trimestral': lambda i: relativedelta(months=i * 3),
+    'semestral': lambda i: relativedelta(months=i * 6),
+    'anual': lambda i: relativedelta(years=i),
+}
+
+
+def calcular_delta_recorrencia(frequencia: str, indice: int) -> relativedelta:
+    try:
+        factory = FREQUENCIA_DELTAS[frequencia]
+    except KeyError as exc:  # pragma: no cover - ChoiceField evita uso inválido
+        raise ValueError(f"Frequência de recorrência inválida: {frequencia}") from exc
+    return factory(indice)
 
 @login_required
 def lista_despesas(request):
@@ -98,13 +118,7 @@ def adicionar_despesa_recorrente(request):
             dados = form.cleaned_data
             id_rec = uuid.uuid4()
             for i in range(dados['repeticoes']):
-                if dados['frequencia'] == 'semanal': delta = relativedelta(weeks=i)
-                elif dados['frequencia'] == 'quinzenal': delta = relativedelta(weeks=i*2)
-                elif dados['frequencia'] == 'mensal': delta = relativedelta(months=i)
-                elif dados['frequencia'] == 'trimestral': delta = relativedelta(months=i*3)
-                elif dados['frequencia'] == 'semestral': delta = relativedelta(months=i*6)
-                elif dados['frequencia'] == 'anual': delta = relativedelta(years=i)
-                data_recorrencia = dados['data_inicio'] + delta
+                data_recorrencia = dados['data_inicio'] + calcular_delta_recorrencia(dados['frequencia'], i)
                 Despesa.objects.create(
                     user=user, descricao=dados['descricao'], valor=dados['valor'], data=data_recorrencia,
                     categoria=dados['categoria'], conta=dados['conta'], cartao=dados['cartao'],
@@ -195,13 +209,7 @@ def adicionar_receita_recorrente(request):
             dados = form.cleaned_data
             id_rec = uuid.uuid4()
             for i in range(dados['repeticoes']):
-                if dados['frequencia'] == 'semanal': delta = relativedelta(weeks=i)
-                elif dados['frequencia'] == 'quinzenal': delta = relativedelta(weeks=i*2)
-                elif dados['frequencia'] == 'mensal': delta = relativedelta(months=i)
-                elif dados['frequencia'] == 'trimestral': delta = relativedelta(months=i*3)
-                elif dados['frequencia'] == 'semestral': delta = relativedelta(months=i*6)
-                elif dados['frequencia'] == 'anual': delta = relativedelta(years=i)
-                data_recorrencia = dados['data_inicio'] + delta
+                data_recorrencia = dados['data_inicio'] + calcular_delta_recorrencia(dados['frequencia'], i)
                 Receita.objects.create(
                     user=user, descricao=dados['descricao'], valor=dados['valor'], data=data_recorrencia,
                     categoria=dados['categoria'], conta=dados['conta'],


### PR DESCRIPTION
## Summary
- avoid evaluating Conta querysets at import time in payment and aporte forms and consolidate the Categoria form definition
- add a reusable frequency-to-delta helper for recurring transactions to remove duplicated branching
- update dashboard tests to reflect the rendered content and actual login redirect target

## Testing
- DEBUG=True SECRET_KEY=test python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68dc3bdae07c832b842efa4789d6f1d7